### PR TITLE
initfun bug in updateOutput function

### DIFF
--- a/rnnlib/nn/SequenceTable.lua
+++ b/rnnlib/nn/SequenceTable.lua
@@ -138,7 +138,7 @@ SequenceTable.updateOutput = argcheck{
     { name = 'input' , type = 'table'            },
     call = function(self, input)
         local d = self.dim
-        if self.initfun then
+        if self.initfun and self.inputs then
             input = self.initfun(input, self.inputs[#self.inputs], d)
         end
         self.inputs = {}


### PR DESCRIPTION
Hi,
I have tried to run the following example with initfun
```Lua
local rnnlib = require 'rnnlib'
local mutils    = require 'rnnlib.mutils'

input = {
    torch.Tensor{ 2 },
    torch.Tensor{ 1, 2, 3, 4 }:split(1),
}

f = function(hid, input)
    local ax   = nn.CMulTable(){hid, input}
    local axpa = nn.CAddTable(){ax, hid}
    return axpa, nn.Identity()(axpa)
end

initfun = function(input, prev, d)
    return input + prev
end

c = rnnlib.cell.gModule(f)
network = nn.RecurrentTable{
    dim    = 2,
    module = c,
    initfun = initfun
}

o = network:forward(input)
print(o[1][1]) 
```
And I have got the following exception 
![image](https://cloud.githubusercontent.com/assets/9088025/20695032/81cb37c6-b5e9-11e6-892f-f610d85e0a49.png)

I proposed to change the line 141 to fix this issue.

thanks.

Mohammed Jabreel